### PR TITLE
fix extra parameters params for the links

### DIFF
--- a/lib/kaminari/helpers/sinatra_helpers.rb
+++ b/lib/kaminari/helpers/sinatra_helpers.rb
@@ -91,7 +91,11 @@ module Kaminari::Helpers
         current_path = env['PATH_INFO'] rescue nil
         current_params = Rack::Utils.parse_query(env['QUERY_STRING']).symbolize_keys rescue {}
 
-        template = ActionViewTemplateProxy.new current_params: current_params, current_path: current_path, param_name: options[:param_name] || Kaminari.config.param_name
+        template = ActionViewTemplateProxy.new(
+          current_params: current_params.merge(options[:params]),
+          current_path: current_path,
+          param_name: options[:param_name] || Kaminari.config.param_name
+        )
 
         super scope, {template: template}.merge(options)
       end

--- a/test/helpers/sinatra_helpers_test.rb
+++ b/test/helpers/sinatra_helpers_test.rb
@@ -168,6 +168,24 @@ class SinatraHelperTest < ActiveSupport::TestCase
           assert_match(/user_page=\d+/, elm.attribute('href').value)
         end
       end
+
+      test 'should allow extra params' do
+        mock_app do
+          register Kaminari::Helpers::SinatraHelpers
+          get '/users' do
+            @page = params[:page] || 1
+            @users = User.page(@page).per(3)
+            @options = {params: {foo: 'bar'}}
+            erb ERB_TEMPLATE_FOR_PAGINATE.dup
+          end
+        end
+
+        get '/users'
+
+        last_document.search('.page a').each do |elm|
+          assert_match(/foo=bar/, elm.attribute('href').value)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
I'm using kaminari with sinatra on a project and I need to use extra parameters with the pagination links. The kaminari documentation describes this here https://github.com/kaminari/kaminari#extra-parameters-params-for-the-links. Unfortunately this doesn't seem to be working with the sinatra gem in my [project](https://github.com/kevinhughes27/shopify-tax-receipts/pull/33) (I didn't test a vanilla application).

I did some digging and this patch fixed the problem for me. I'm not sure it is the best solution since merging the idea of `current_params` and `extra_params` might be confusing but this was the fix with the least impact on the existing code so I thought I would start here. I'm happy to go further with some guidance from a maintainer. 

Also the tests crashed on my machine so hopefully travis still runs.